### PR TITLE
The Aether enchanter/altar repairing support for DwMG on 1.19.2

### DIFF
--- a/src/main/resources/data/dwmg/recipes/aether/necromancer_hat_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/necromancer_hat_repairing_1_19_2.json
@@ -11,5 +11,5 @@
   "ingredient": {
     "item": "dwmg:necromancer_hat"
   },
-  "repairTime": 750
+  "repairTime": 1500
 }

--- a/src/main/resources/data/dwmg/recipes/aether/necromancer_hat_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/necromancer_hat_repairing_1_19_2.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "aether:repairing",
+  "category": "enchanting_repair",
+  "group": "altar_helmet_repair",
+  "ingredient": {
+    "item": "dwmg:necromancer_hat"
+  },
+  "repairTime": 750
+}

--- a/src/main/resources/data/dwmg/recipes/aether/netherite_fork_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/netherite_fork_repairing_1_19_2.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "aether:repairing",
+  "category": "enchanting_repair",
+  "group": "altar_sword_repair",
+  "ingredient": {
+    "item": "dwmg:netherite_fork"
+  },
+  "repairTime": 1250
+}

--- a/src/main/resources/data/dwmg/recipes/aether/netherite_fork_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/netherite_fork_repairing_1_19_2.json
@@ -11,5 +11,5 @@
   "ingredient": {
     "item": "dwmg:netherite_fork"
   },
-  "repairTime": 1250
+  "repairTime": 2000
 }

--- a/src/main/resources/data/dwmg/recipes/aether/peach_wood_sword_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/peach_wood_sword_repairing_1_19_2.json
@@ -11,5 +11,5 @@
   "ingredient": {
     "item": "dwmg:peach_wood_sword"
   },
-  "repairTime": 500
+  "repairTime": 250
 }

--- a/src/main/resources/data/dwmg/recipes/aether/peach_wood_sword_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/peach_wood_sword_repairing_1_19_2.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "aether:repairing",
+  "category": "enchanting_repair",
+  "group": "altar_sword_repair",
+  "ingredient": {
+    "item": "dwmg:peach_wood_sword"
+  },
+  "repairTime": 500
+}

--- a/src/main/resources/data/dwmg/recipes/aether/reinforced_fishing_rod_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/reinforced_fishing_rod_repairing_1_19_2.json
@@ -1,0 +1,14 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "aether:repairing",
+  "category": "enchanting_repair",
+  "ingredient": {
+    "item": "dwmg:reinforced_fishing_rod"
+  },
+  "repairTime": 1200
+}

--- a/src/main/resources/data/dwmg/recipes/aether/reinforced_fishing_rod_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/reinforced_fishing_rod_repairing_1_19_2.json
@@ -10,5 +10,5 @@
   "ingredient": {
     "item": "dwmg:reinforced_fishing_rod"
   },
-  "repairTime": 1200
+  "repairTime": 750
 }

--- a/src/main/resources/data/dwmg/recipes/aether/sunhat_repairing_1_19_2.json
+++ b/src/main/resources/data/dwmg/recipes/aether/sunhat_repairing_1_19_2.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "aether:repairing",
+  "category": "enchanting_repair",
+  "group": "altar_helmet_repair",
+  "ingredient": {
+    "item": "dwmg:sunhat"
+  },
+  "repairTime": 250
+}


### PR DESCRIPTION
I am very sorry if this happens to have been a nuisance to you. I have little to no clue what I am doing.

This is specifically for 1.19.2, the other versions of aether omit "category": "enchanting_repair",