### PR TITLE
Edit NFF Trade

### DIFF
--- a/src/main/resources/data/nffgirls/healing/animal.json
+++ b/src/main/resources/data/nffgirls/healing/animal.json
@@ -34,5 +34,53 @@
   {
     "item": "minecraft:golden_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexsmobs:cooked_moose_ribs",
+    "amount": [10]
+  },
+  {
+    "item": "alexsmobs:cooked_kangaroo_meat",
+    "amount": [10]
+  },
+  {
+    "item": "twilightforest:cooked_venison",
+    "amount": [10]
+  },
+  {
+    "item": "twilightforest:hydra_chop",
+    "amount": [30]
+  },
+  {
+    "item": "alexscaves:dinosaur_nugget",
+    "amount": [20]
+  },
+  {
+    "item": "farmersdelight:beef_patty",
+    "amount": [10]
+  },
+  {
+    "item": "farmersdelight:cooked_mutton_chops",
+    "amount": [8]
+  },
+  {
+    "item": "farmersdelight:cooked_bacon",
+    "amount": [10]
+  },
+  {
+    "item": "farmersdelight:cooked_chicken_cuts",
+    "amount": [8]
+  },
+  {
+    "item": "farmersdelight:smoked_ham",
+    "amount": [15]
+  },
+  {
+    "item": "grimoireofgaia:meat",
+    "amount": [12]
+  },
+  {
+    "item": "grimoireofgaia:golden_apple_pie_slice",
+    "amount_getter": "nffgirls:mob_max_health"
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/bee.json
+++ b/src/main/resources/data/nffgirls/healing/bee.json
@@ -14,5 +14,9 @@
   {
     "item": "hmag:mysterious_petal",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:honeydew",
+    "amount": [20]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/blaze.json
+++ b/src/main/resources/data/nffgirls/healing/blaze.json
@@ -14,5 +14,17 @@
   {
     "item": "hmag:burning_core",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:tectonic_shard",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:stone_coal",
+    "amount": [20]
+  },
+  {
+    "item": "grimoireofgaia:fireshard",
+    "amount": [20]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/clay_doll.json
+++ b/src/main/resources/data/nffgirls/healing/clay_doll.json
@@ -8,11 +8,35 @@
     "amount": [5]
   },
   {
+    "item": "minecraft:amethyst_shard",
+    "amount": [8]
+  },
+  {
     "item": "hmag:ancient_stone",
     "amount": [15]
   },
   {
     "item": "minecraft:golden_apple",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:golden_apple_pie_slice",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexsmobs:straddlite",
+    "amount": [20]
+  },
+  {
+    "item": "cataclysm:amethyst_crab_shell",
+    "amount": [20]
+  },
+  {
+    "item": "ars_nouveau:source_gem",
+    "amount": [15]
+  },
+  {
+    "item": "alexsmobs:guster_eye",
     "amount_getter": "nffgirls:mob_max_health"
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/cloth_doll.json
+++ b/src/main/resources/data/nffgirls/healing/cloth_doll.json
@@ -34,5 +34,9 @@
   {
     "item": "hmag:cubic_nucleus",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "twilightforest:red_thread",
+    "amount": [15]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/creeper.json
+++ b/src/main/resources/data/nffgirls/healing/creeper.json
@@ -10,5 +10,17 @@
   {
     "item": "minecraft:redstone_block",
     "amount": [15]
+  },
+  {
+    "item": "alexscaves:tesla_bulb",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:fissile_core",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:sulfur_dust",
+    "amount": [5]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/crimson.json
+++ b/src/main/resources/data/nffgirls/healing/crimson.json
@@ -14,5 +14,17 @@
   {
     "item": "minecraft:golden_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexsmobs:mosquito_larva",
+    "amount": [15]
+  },
+  {
+    "item": "grimoireofgaia:golden_apple_pie_slice",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:nether_wart_jam",
+    "amount": [30]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/enderman.json
+++ b/src/main/resources/data/nffgirls/healing/enderman.json
@@ -6,5 +6,13 @@
   {
     "item": "hmag:ancient_stone",
     "amount": [15]
+  },
+  {
+    "item": "alexsmobs:cosmic_cod",
+    "amount": [10]
+  },
+  {
+    "item": "alexsmobs:void_worm_eye",
+    "amount_getter": "nffgirls:mob_max_health"
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/general_humanoid_0.json
+++ b/src/main/resources/data/nffgirls/healing/general_humanoid_0.json
@@ -22,5 +22,45 @@
   {
     "item": "minecraft:golden_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:caramel_apple",
+    "amount": [20]
+  },
+  {
+    "item": "farmersdelight:honey_cookie",
+    "amount": [5]
+  },
+  {
+    "item": "farmersdelight:sweet_berry_cookie",
+    "amount": [5]
+  },
+  {
+    "item": "farmersdelight:chocolate_pie_slice",
+    "amount": [8]
+  },
+  {
+    "item": "farmersdelight:sweet_berry_cheesecake_slice",
+    "amount": [8]
+  },
+  {
+    "item": "farmersdelight:apple_pie_slice",
+    "amount": [8]
+  },
+  {
+    "item": "farmersdelight:cake_slice",
+    "amount": [8]
+  },
+  {
+    "item": "ars_nouveau:source_berry_pie",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "ars_nouveau:source_berry_roll",
+    "amount": [15]
+  },
+  {
+    "item": "grimoireofgaia:golden_apple_pie_slice",
+    "amount_getter": "nffgirls:mob_max_health"
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/ghast.json
+++ b/src/main/resources/data/nffgirls/healing/ghast.json
@@ -10,5 +10,17 @@
   {
     "item": "hmag:soul_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "twilightforest:fiery_tears",
+    "amount": [20]
+  },
+  {
+    "item": "twilightforest:fiery_blood",
+    "amount": [20]
+  },
+  {
+    "item": "twilightforest:experiment_115",
+    "amount": [15]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/plant.json
+++ b/src/main/resources/data/nffgirls/healing/plant.json
@@ -14,5 +14,25 @@
   {
     "item": "hmag:mysterious_petal",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "twilightforest:magic_beans",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:mandrake",
+    "amount": [20]
+  },
+  {
+    "item": "alexscaves:fertilizer",
+    "amount": [15]
+  },
+  {
+    "item": "farmersdelight:organic_compost",
+    "amount": [15]
+  },
+  {
+    "item": "twilightforest:uberous_soil",
+    "amount": [15]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/slime.json
+++ b/src/main/resources/data/nffgirls/healing/slime.json
@@ -10,5 +10,21 @@
   {
     "item": "hmag:cubic_nucleus",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexsmobs:mimicream",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:ferrouslime_ball",
+    "amount": [15]
+  },
+  {
+    "item": "alexscaves:ferrouslime_ball",
+    "amount": [15]
+  },
+  {
+    "tag": "alexscaves:gelatins",
+    "amount": [10]
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/snowman.json
+++ b/src/main/resources/data/nffgirls/healing/snowman.json
@@ -14,5 +14,21 @@
   {
     "item": "minecraft:golden_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexscaves:chocolate_ice_cream",
+    "amount": [10]
+  },
+  {
+    "item": "alexscaves:sweetberry_ice_cream",
+    "amount": [10]
+  },
+  {
+    "item": "alexscaves:vanilla_ice_cream",
+    "amount": [10]
+  },
+  {
+    "item": "grimoireofgaia:golden_apple_pie_slice",
+    "amount_getter": "nffgirls:mob_max_health"
   }
 ]

--- a/src/main/resources/data/nffgirls/healing/undead.json
+++ b/src/main/resources/data/nffgirls/healing/undead.json
@@ -14,5 +14,25 @@
   {
     "item": "hmag:soul_apple",
     "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "alexsmobs:soul_heart",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "cataclysm:koboleton_bone",
+    "amount": [15]
+  },
+  {
+    "item": "alexscaves:darkened_apple",
+    "amount_getter": "nffgirls:mob_max_health"
+  },
+  {
+    "item": "grimoireofgaia:rotten_heart",
+    "amount": [15]
+  },
+  {
+    "item": "grimoireofgaia:soulfire",
+    "amount": [15]
   }
 ]

--- a/src/main/resources/data/nffgirls/trades/entry_registry.json
+++ b/src/main/resources/data/nffgirls/trades/entry_registry.json
@@ -6,8 +6,7 @@
     "item": "hmag:greedy_crystal",
     "amount": 1,
     "price": [36, 48],
-    "maxUses": 1,
-    "weight": 0.3
+    "maxUses": 1
   },
   {
     "key": "sells_fortune_crystal",
@@ -16,8 +15,7 @@
     "item": "hmag:fortune_crystal",
     "amount": 1,
     "price": [36, 48],
-    "maxUses": 1,
-    "weight": 0.3
+    "maxUses": 1
   },
   {
     "key": "sells_greedy_crystal_plus",
@@ -26,8 +24,7 @@
     "item": "hmag:greedy_crystal_plus",
     "amount": 1,
     "price": 64,
-    "maxUses": 1,
-    "weight": 0.1
+    "maxUses": 1
   },
   {
     "key": "sells_fortune_crystal_plus",
@@ -36,7 +33,6 @@
     "item": "hmag:fortune_crystal_plus",
     "amount": 1,
     "price": 64,
-    "maxUses": 1,
-    "weight": 0.1
+    "maxUses": 1
   }
 ]

--- a/src/main/resources/data/nffgirls/trades/hmag_dodomeki.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_dodomeki.json
@@ -36,9 +36,9 @@
     "level": 2,
     "type": "sell",
     "item": "nffgirls:death_crystal_powder",
-    "amount": 1,
-    "price": [3, 5],
-    "maxUses": 4
+    "amount": 4,
+    "price": 1,
+    "maxUses": 2
   },
   {
     "level": 3,

--- a/src/main/resources/data/nffgirls/trades/hmag_drowned_girl.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_drowned_girl.json
@@ -27,7 +27,7 @@
     "level": 3,
     "type": "buy",
     "item": "hmag:swamper_tentacle",
-    "amount": [4, 6],
+    "amount": [6, 10],
     "price": 1,
     "maxUses": 2
   },

--- a/src/main/resources/data/nffgirls/trades/hmag_ender_executor.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_ender_executor.json
@@ -36,14 +36,6 @@
   {
     "level": 3,
     "type": "sell",
-    "item": "nffgirls:enderberry",
-    "amount": 1,
-    "price": [6, 10],
-    "maxUses": 4
-  },
-  {
-    "level": 3,
-    "type": "sell",
     "item": "minecraft:shulker_shell",
     "amount": [2, 3],
     "price": 1,

--- a/src/main/resources/data/nffgirls/trades/hmag_harpy.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_harpy.json
@@ -36,7 +36,7 @@
     "level": 3,
     "type": "buy",
     "item": "hmag:swamper_tentacle",
-    "amount": [4, 6],
+    "amount": [6, 10],
     "price": 1,
     "maxUses": 2
   },

--- a/src/main/resources/data/nffgirls/trades/hmag_jack_frost.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_jack_frost.json
@@ -62,15 +62,6 @@
   {
     "level": 5,
     "type": "sell",
-    "item": "hmag:fortune_crystal",
-    "amount": 1,
-    "price": [36, 48],
-    "maxUses": 1,
-    "weight": 0.3
-  },
-  {
-    "level": 5,
-    "type": "sell",
     "item": "minecraft:enchanted_golden_apple",
     "amount": 1,
     "price": [6, 8],
@@ -78,11 +69,14 @@
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:fortune_crystal_plus",
-    "amount": 1,
-    "price": [64, 64],
-    "maxUses": 1,
+    "type": "registry",
+    "key": "nffgirls:sells_fortune_crystal",
+    "weight": 0.3
+  },
+  {
+    "level": 5,
+    "type": "registry",
+    "key": "nffgirls:sells_fortune_crystal_plus",
     "weight": 0.1
   },
   {

--- a/src/main/resources/data/nffgirls/trades/hmag_slime_girl.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_slime_girl.json
@@ -87,20 +87,14 @@
   
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:fortune_crystal",
-    "amount": 1,
-    "price": [36, 48],
-    "maxUses": 2,
+    "type": "registry",
+    "key": "nffgirls:sells_fortune_crystal",
     "weight": 0.3
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:fortune_crystal_plus",
-    "amount": 1,
-    "price": [64, 64],
-    "maxUses": 1,
+    "type": "registry",
+    "key": "nffgirls:sells_fortune_crystal_plus",
     "weight": 0.1
   },
   {

--- a/src/main/resources/data/nffgirls/trades/hmag_snow_canine.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_snow_canine.json
@@ -84,19 +84,14 @@
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:greedy_crystal",
-    "amount": 1,
-    "price": [36, 48],
-    "maxUses": 2
+    "type": "registry",
+    "key": "nffgirls:sells_greedy_crystal",
+    "weight": 0.3
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:greedy_crystal_plus",
-    "amount": 1,
-    "price": [64, 64],
-    "maxUses": 1,
+    "type": "registry",
+    "key": "nffgirls:sells_greedy_crystal_plus",
     "weight": 0.1
   },
   {

--- a/src/main/resources/data/nffgirls/trades/hmag_stray_girl.json
+++ b/src/main/resources/data/nffgirls/trades/hmag_stray_girl.json
@@ -33,19 +33,14 @@
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:greedy_crystal",
-    "amount": 1,
-    "price": [36, 48],
-    "maxUses": 2
+    "type": "registry",
+    "key": "nffgirls:sells_greedy_crystal",
+    "weight": 0.3
   },
   {
     "level": 5,
-    "type": "sell",
-    "item": "hmag:greedy_crystal_plus",
-    "amount": 1,
-    "price": [64, 64],
-    "maxUses": 1,
+    "type": "registry",
+    "key": "nffgirls:sells_greedy_crystal_plus",
     "weight": 0.1
   },
   {

--- a/src/main/resources/data/nffgirls/trades/trade_registry.json
+++ b/src/main/resources/data/nffgirls/trades/trade_registry.json
@@ -2,124 +2,138 @@
   {
     "key": "nffgirls:hmag_zombie_girl",
     "collections": [
-      "nffgirls:common_undead",
-      "nffgirls:common_zombie"
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_zombie", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_husk_girl",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.5},
-      {"key": "nffgirls:common_zombie", "weight": 0.5}
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_zombie", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_drowned_girl",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.3},
-      {"key": "nffgirls:common_zombie", "weight": 0.3},
-      {"key": "nffgirls:common_aquatic","weight": 0.5}
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_zombie", "weight": 0.2},
+      {"key": "nffgirls:common_aquatic","weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_skeleton_girl",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.8},
-      "nffgirls:common_skeleton",
-      "nffgirls:common_archer"
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_archer", "weight": 0.2},
+      {"key": "nffgirls:common_skeleton", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_stray_girl",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.5},
-      {"key": "nffgirls:common_archer", "weight": 0.5},
-      {"key": "nffgirls:common_skeleton", "weight": 0.5},
-      {"key": "nffgirls:common_ice", "weight": 0.5}
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_archer", "weight": 0.2},
+      {"key": "nffgirls:common_skeleton", "weight": 0.2},
+      {"key": "nffgirls:common_ice", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_wither_skeleton_girl",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.5},
+      {"key": "nffgirls:common_undead", "weight": 0.1},
       {"key": "nffgirls:common_archer", "weight": 0.2},
-      {"key": "nffgirls:common_skeleton", "weight": 0.5},
-      {"key": "nffgirls:common_nether", "weight": 0.5}
+      {"key": "nffgirls:common_skeleton", "weight": 0.2},
+      {"key": "nffgirls:common_nether", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_ender_executor",
-    "collections": "nffgirls:common_ender"
+    "collections": [
+	  {"key": "nffgirls:common_ender", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_ghastly_seeker",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.2},
-      {"key": "nffgirls:common_nether", "weight": 0.5}
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_nether", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_creeper_girl",
-    "collections": "nffgirls:common_explosive"
+	"collections": [
+	  {"key": "nffgirls:common_explosive", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_necrotic_reaper",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.7},
-      {"key": "nffgirls:common_zombie", "weight": 0.1},
-      {"key": "nffgirls:common_skeleton", "weight": 0.1}
+      {"key": "nffgirls:common_undead", "weight": 0.1},
+      {"key": "nffgirls:common_zombie", "weight": 0.2},
+      {"key": "nffgirls:common_skeleton", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_melty_monster",
-    "collections": "nffgirls:common_nether"
+	"collections": [
+	  {"key": "nffgirls:common_nether", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_alraune",
-    "collections": "nffgirls:common_plant"
+	"collections": [
+	  {"key": "nffgirls:common_plant", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_glaryad",
-    "collections": "nffgirls:common_plant"
+	"collections": [
+	  {"key": "nffgirls:common_plant", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_banshee",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.5}
+      {"key": "nffgirls:common_undead", "weight": 0.1}
     ]
   },
   {
     "key": "nffgirls:hmag_crimson_slaughterer",
     "collections": [
-      {"key": "nffgirls:common_nether", "weight": 0.5}
+      {"key": "nffgirls:common_nether", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_harpy",
-    "collections": "nffgirls:common_animal"
+	"collections": [
+	  {"key": "nffgirls:common_animal", "weight": 0.2}
+	]
   },
   {
     "key": "nffgirls:hmag_snow_canine",
     "collections": [
-      "nffgirls:common_animal",
-      {"key": "nffgirls:common_ice", "weight": 0.3}
+      {"key": "nffgirls:common_animal", "weight": 0.2},
+      {"key": "nffgirls:common_ice", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_imp",
     "collections": [
-      {"key": "nffgirls:common_nether", "weight": 0.5}
+      {"key": "nffgirls:common_nether", "weight": 0.2}
     ]
   },
   {
     "key": "nffgirls:hmag_jiangshi",
     "collections": [
-      {"key": "nffgirls:common_undead", "weight": 0.3}
+      {"key": "nffgirls:common_undead", "weight": 0.1}
     ]
   },
   {
     "key": "nffgirls:hmag_jack_frost",
-    "collections": "nffgirls:common_ice"
+	"collections": [
+	  {"key": "nffgirls:common_ice", "weight": 0.2}
+	]
   },
   "nffgirls:hmag_dullahan",
   "nffgirls:hmag_dodomeki",


### PR DESCRIPTION
1.修复了一些交易条目的数据错误
2.鉴于实测刷出怪物娘独有交易的概率较低，降低通用交易的占比
3.增加治疗道具的联动条目，希望能直接整合进模组本身