### PR TITLE
fix data reload breaking because of ambiguous packet flinging

### DIFF
--- a/src/main/java/net/sodiumzh/nff/girls/jei/NFFGirlsJeiEventListeners.java
+++ b/src/main/java/net/sodiumzh/nff/girls/jei/NFFGirlsJeiEventListeners.java
@@ -45,7 +45,10 @@ public class NFFGirlsJeiEventListeners {
                 NFUNetworkStatics.sendToPlayer(NFFGirlsChannels.SYNC_CHANNEL,
                     packet, event.getPlayer()),
             () ->
-                event.getPlayerList().broadcastAll(packet));
+                    event.getPlayerList().getPlayers().forEach(player -> {
+                        NFUNetworkStatics.sendToPlayer(NFFGirlsChannels.SYNC_CHANNEL,
+                                packet, player);
+                    }));
     }
 
 }

--- a/src/main/java/net/sodiumzh/nff/girls/jei/NFFGirlsJeiStatics.java
+++ b/src/main/java/net/sodiumzh/nff/girls/jei/NFFGirlsJeiStatics.java
@@ -11,6 +11,8 @@ import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.sodiumzh.nff.girls.jei.item.MobApplicableItemTableJeiRecord;
@@ -22,7 +24,6 @@ import net.sodiumzh.nff.girls.registry.NFFGirlsHealingItems;
 import net.sodiumzh.nff.girls.registry.NFFGirlsTrades;
 import net.sodiumzh.nff.services.entity.taming.IItemTableUsingProcess;
 import net.sodiumzh.nff.services.entity.taming.NFFTamingMapping;
-import net.sodiumzh.nff.services.entity.taming.TamingProcessItemGivingProgress;
 import net.sodiumzh.nfu.container.Tuple2;
 import net.sodiumzh.nfu.container.Tuple3;
 import net.sodiumzh.nfu.entity.MobApplicableItemTable;
@@ -97,6 +98,7 @@ public class NFFGirlsJeiStatics {
             }));
     }
 
+    @OnlyIn(Dist.CLIENT)
     // Client side
     public static void requestJeiDataSync(Player player) {
         if(!player.level().isClientSide) return;
@@ -110,7 +112,8 @@ public class NFFGirlsJeiStatics {
         }
     }
 
-    // Server side
+    @OnlyIn(Dist.CLIENT)
+    // Client side
     public static void handleJeiDataSync(ClientboundNFFGirlsJeiDataSyncPacket packet, ClientGamePacketListener pHandler) {
         if (!ModList.get().isLoaded("jei")) return;
         Minecraft mc = Minecraft.getInstance();


### PR DESCRIPTION
`Caused by: java.lang.IllegalStateException: Encountered packet without set protocol: net.sodiumzh.nff.girls.jei.ClientboundNFFGirlsJeiDataSyncPacket`